### PR TITLE
Completely disable caching for preview

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -3,4 +3,5 @@ file_server {
 	root /preview/public/serve
 	index index.html
 }
+header Cache-Control "no-store"
 encode zstd gzip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM vshn/antora:3.1.1
+FROM docker.io/vshn/antora:3.1.1
 
 RUN addgroup -S preview && adduser -S preview -G preview && \
     mkdir -p /preview/bundles && chown -R preview:preview /preview


### PR DESCRIPTION
Set the HTTP header `Cache-Control` to `no-store` to improve development experience when switching between different Antora sites.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control for a description about this header.

> The `no-store` response directive indicates that any caches of any kind (private or shared) should not store this response.